### PR TITLE
Enable `system` feature for `libffi` on macOS + Apple Silicon

### DIFF
--- a/crates/brontes-database/libmdbx-rs/Cargo.toml
+++ b/crates/brontes-database/libmdbx-rs/Cargo.toml
@@ -25,14 +25,16 @@ tempfile = "3.8"
 criterion = "0.5"
 pprof = "0.13"
 
-[target.'cfg(not(windows))'.dependencies]
+# For macOS ARM64: use system libffi, as building from source does not work
+# you can install it via brew install libffi
+[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
+libffi = { version = "3.2.0", features = ["system"] }
+
+# For everything else (non-Windows): build from source
+[target.'cfg(all(not(windows), not(all(target_os = "macos", target_arch = "aarch64"))))'.dependencies]
 libffi = "3.2.0"
 
 [features]
 default = []
 return-borrowed = []
 read-tx-timeouts = ["dashmap", "dashmap/inline"]
-
-
-
-


### PR DESCRIPTION
On macOS w/ Apple Silicon, local builds of `brontes` fail because `libffi` is unable to be built from source which is it's default method. 

You can manually install an arm64 build of `libffi` via homebrew though by doing `brew install libffi` and then configure `libffi` to have the `system` feature enabled which will use the prebuilt `libffi` on the system rather than attempting to build from source

This PR configures the dependency so that on macOS + arm64 it will have the `system` feature enabled, and otherwise keep the same behavior as before.